### PR TITLE
Some fixes for Windows with Anaconda

### DIFF
--- a/pywrap/template_data/setup.template
+++ b/pywrap/template_data/setup.template
@@ -9,8 +9,9 @@ import os
 def strict_prototypes_workaround():
     # Workaround to remove '-Wstrict-prototypes' from compiler invocation
     opt = get_config_vars('OPT')[0]
-    os.environ['OPT'] = " ".join(flag for flag in opt.split()
-                                 if flag != '-Wstrict-prototypes')
+    if opt is not None:
+        os.environ['OPT'] = " ".join(flag for flag in opt.split()
+                                     if flag != '-Wstrict-prototypes')
 
 
 if __name__ == '__main__':

--- a/pywrap/test/test_libclang.py
+++ b/pywrap/test/test_libclang.py
@@ -1,7 +1,7 @@
-from pywrap.libclang import find_clang
+from pywrap.libclang import find_clang, SUPPORTED_VERSIONS
 from nose.tools import assert_in
 
 
 def test_find_clang():
     CLANG_VERSION, CLANG_INCDIR = find_clang(set_library_path=False, verbose=2)
-    assert_in(CLANG_VERSION, ["3.5", "3.6", "3.7", "3.8"])
+    assert_in(CLANG_VERSION, SUPPORTED_VERSIONS)

--- a/test/addincludedir.hpp
+++ b/test/addincludedir.hpp
@@ -1,7 +1,8 @@
 #include "somefunction.hpp"
-#include <cmath>
 
 double length(double a, double b)
 {
-    return std::sqrt(square(a) + square(b));
+    const absA = a > 0 ? a : -a;
+    const absB = b > 0 ? b : -b;
+    return absA + absB;
 }

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -61,4 +61,4 @@ def test_another_include_dir():
     with cython_extension_from("addincludedir.hpp",
                                incdirs=["anotherincludedir"]):
         from addincludedir import length
-        assert_equal(length(3.0, 4.0), 5.0)
+        assert_equal(length(3.0, -4.0), 7.0)


### PR DESCRIPTION
Required packages:

```bash
conda install cython
conda install -c statiskit clang
conda install -c statiskit python-clang
```

There are some issues at the moment:
* the C++ compiler does not seem to be set correctly (`error: Unable to find vcvarsall.bat`)
* standard lib headers are not available (`cmath`, `vector`, ...)